### PR TITLE
bugfix dot user

### DIFF
--- a/usr/share/se3/sbin/clean_profiles.sh
+++ b/usr/share/se3/sbin/clean_profiles.sh
@@ -15,7 +15,7 @@ if [ "$1" = "all" ];then
 
 	for dossier in $(ls /home/profiles/ 2>/dev/null)
 		do
-			user=$(echo "$dossier" | cut -d "." -f1)
+			user=$(echo "$dossier" | sed -re 's/\.V([0-9]*)$//g')
 			if [ -z "$(grep "$user" $temoin)" ]; then
 				echo "$user" >> $temoin
 				echo "Suppression profil Utilisateur $user <br/>"


### PR DESCRIPTION
Si on utilise la paterne "prenom.nom" pour les logins, le script coupe le nom du login et donc ne fonctionne pas lors du "rm"
```bash
echo "martin.dupont.V2" | cut -d "." -f1 # martin
```

Je pense qu'il est préférable de tronquer les ".V2" à la place :
```bash
echo "martin.dupont.V2" | sed -re 's/\.V([0-9]*)$//g' # martin.dupont
```
